### PR TITLE
Fix typo in the `merge` section

### DIFF
--- a/branching/index.html
+++ b/branching/index.html
@@ -301,7 +301,7 @@ HelloWorld.hello
 
     <p>Bây giờ ta đang ở nhánh 'master'. Ta sẽ tạo nhánh 'change_class'
     và rẽ ngay vào nhánh đó: trong nhánh mới ta sẽ thực hiện đổi tên lớp
-    từ 'HelloWorld' dthành 'HiWorld'.</p>
+    từ 'HelloWorld' thành 'HiWorld'.</p>
 
 <pre>
 <b>$ git checkout -b change_class</b>


### PR DESCRIPTION
Fix typo, 's/dthành/thành' at line 204
